### PR TITLE
Resumable

### DIFF
--- a/src/main/java/weka/classifiers/functions/Dl4jMlpClassifier.java
+++ b/src/main/java/weka/classifiers/functions/Dl4jMlpClassifier.java
@@ -155,10 +155,15 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
    * The number of epochs to perform.
    */
   protected int numEpochs = 10;
+  /** The current upper bound for the number of epochs */
+  protected int maxEpochs = 0;
   /**
-   * The number of epochs that have been performed.
+   * The total number of epochs that have been performed.
    */
   protected int numEpochsPerformed;
+
+  /** The number of epochs performed in this session of iterating */
+  protected int numEpochsPerformedThisSession;
   /**
    * The dataset trainIterator.
    */
@@ -211,6 +216,12 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
    */
   protected LogConfiguration logConfig = new LogConfiguration();
 
+  /**
+   * Whether to allow training to continue at a later point after the initial
+   * model is built.
+   */
+  protected boolean m_resume;
+
 
   /**
    * Get the log configuration.
@@ -231,8 +242,7 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
           description = "The log configuration.",
           commandLineParamName = "logConfig",
           commandLineParamSynopsis = "-logConfig <LogConfiguration>",
-          displayOrder = 1
-  )
+          displayOrder = 1)
   public void setLogConfig(LogConfiguration logConfig) {
     this.logConfig = logConfig;
   }
@@ -618,6 +628,34 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
   }
 
   /**
+   * If called with argument true, then the next time done() is called the model is effectively
+   * "frozen" and no further iterations can be performed
+   *
+   * @param resume true if the model is to be finalized after performing iterations
+   */
+
+  @OptionMetadata(description = "Set whether training can be resumed at a later date",
+    displayName = "Allow training to be resumed after the set number of epochs",
+    commandLineParamName = "resume",
+    commandLineParamSynopsis = "-resume",
+    commandLineParamIsFlag = true,
+    displayOrder = 31)
+  public void setResume(boolean resume) {
+    m_resume = resume;
+  }
+
+  /**
+   * Returns true if the model is to be finalized (or has been finalized) after
+   * training.
+   *
+   * @return the current value of finalize
+   */
+  public boolean getResume() {
+    return m_resume;
+  }
+
+
+  /**
    * The method used to train the classifier.
    *
    * @param data set of instances serving as training data
@@ -654,9 +692,18 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
   public void initializeClassifier(Instances data) throws Exception {
     logConfig.apply();
 
+    if (trainData != null && trainData.numInstances() > 0) {
+      return;
+    }
+
+    if (trainData != null) {
+      if (!trainData.equalHeaders(data)) {
+        throw new WekaException(trainData.equalHeadersMsg(data));
+      }
+    }
 
     // If only class is present, build zeroR
-    if (data.numAttributes() == 1 && data.classIndex() == 0) {
+    if (zeroR == null && data.numAttributes() == 1 && data.classIndex() == 0) {
       zeroR = new ZeroR();
       zeroR.buildClassifier(data);
       return;
@@ -698,11 +745,13 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
     try {
       Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
 
-      // If zoo model was set, use this model as internal MultiLayerNetwork
-      if (useZooModel()) {
-        createZooModel();
-      } else {
-        createModel();
+      if (model == null) {
+        // If zoo model was set, use this model as internal MultiLayerNetwork
+        if (useZooModel()) {
+          createZooModel();
+        } else {
+          createModel();
+        }
       }
       // Initialize iterator
       instanceIterator.initialize();
@@ -715,10 +764,12 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
         log.info(model.conf().toYaml());
       }
 
+      // numEpochsPerformed = 0;
+      numEpochsPerformedThisSession = 0;
+      maxEpochs += numEpochs; // set the current upper bound
+
       // Set the iteration listener
       model.setListeners(getListener());
-
-      numEpochsPerformed = 0;
 
       isInitializationFinished = true;
     } finally {
@@ -1201,10 +1252,12 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
 
     // Initialize weka listener
     if (iterationListener instanceof weka.dl4j.listener.EpochListener) {
-      int numEpochs = getNumEpochs();
+      // int numEpochs = getNumEpochs();
+      int numEpochs = maxEpochs;
       iterationListener
           .init(
               trainData.numClasses(),
+              numEpochsPerformed,
               numEpochs,
               numSamples,
               trainIterator,
@@ -1219,7 +1272,7 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
    */
   public boolean next() throws Exception {
 
-    if (numEpochsPerformed >= getNumEpochs() || zeroR != null || trainData == null) {
+    if (numEpochsPerformedThisSession >= getNumEpochs() || zeroR != null || trainData == null) {
       return false;
     }
 
@@ -1238,7 +1291,8 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
       trainIterator.reset();
       sw.stop();
       numEpochsPerformed++;
-      log.info("Epoch [{}/{}] took {}", numEpochsPerformed, numEpochs, sw.toString());
+      numEpochsPerformedThisSession++;
+      log.info("Epoch [{}/{}] took {}", numEpochsPerformed, maxEpochs, sw.toString());
     } finally {
       Thread.currentThread().setContextClassLoader(origLoader);
     }
@@ -1274,7 +1328,7 @@ public class Dl4jMlpClassifier extends RandomizableClassifier
    */
   public void done() {
 
-    trainData = null;
+    trainData = new Instances(trainData,0);
   }
 
   /**

--- a/src/main/java/weka/core/LogConfiguration.java
+++ b/src/main/java/weka/core/LogConfiguration.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Enumeration;
 
 /**
  * General logger configuration.
@@ -44,7 +45,7 @@ import java.util.Collection;
  * @author Steven Lang
  */
 @Log4j2
-public class LogConfiguration implements Serializable {
+public class LogConfiguration implements Serializable, OptionHandler {
 
     private static final long serialVersionUID = 7910114399022582661L;
     /**
@@ -297,6 +298,34 @@ public class LogConfiguration implements Serializable {
      */
     protected void updateLogLevel(String loggerName, LogLevel level) {
         Configurator.setLevel(loggerName, level.getLevel());
+    }
+
+    /**
+     * Returns an enumeration describing the available options.
+     *
+     * @return an enumeration of all the available options
+     */
+    @Override public Enumeration<Option> listOptions() {
+        return Option.listOptionsForClass(this.getClass()).elements();
+    }
+
+    /**
+     * Parses a given list of options.
+     *
+     * @param options the list of options as an array of strings
+     * @throws Exception if an option is not supported
+     */
+    @Override public void setOptions(String[] options) throws Exception {
+        Option.setOptions(options, this, this.getClass());
+    }
+
+    /**
+     * Gets the current settings of the log configuration
+     *
+     * @return return an array of strings suitable for passing to setOptions
+     */
+    @Override public String[] getOptions() {
+        return Option.getOptions(this, this.getClass());
     }
 
     /**

--- a/src/main/java/weka/dl4j/listener/EpochListener.java
+++ b/src/main/java/weka/dl4j/listener/EpochListener.java
@@ -44,7 +44,7 @@ public class EpochListener extends TrainingListener {
   private static final long serialVersionUID = -8852994767947925554L;
 
   /** Epoch counter */
-  private int currentEpoch = 0;
+  // private int currentEpoch = 0;
 
   /** Evaluate every N epochs */
   private int n = 5;

--- a/src/main/java/weka/dl4j/listener/TrainingListener.java
+++ b/src/main/java/weka/dl4j/listener/TrainingListener.java
@@ -43,6 +43,8 @@ public abstract class TrainingListener
   protected int numClasses;
   /** Number of classes */
   protected int numEpochs;
+  /** The current epoch */
+  protected int currentEpoch;
   /** Training dataset iterator */
   protected transient DataSetIterator validationIterator;
   /** Validation dataset iterator */
@@ -58,11 +60,13 @@ public abstract class TrainingListener
    */
   public void init(
       int numClasses,
+      int currentEpoch,
       int numEpochs,
       int numSamples,
       DataSetIterator trainIterator,
       DataSetIterator validationIterator) {
     this.numClasses = numClasses;
+    this.currentEpoch = currentEpoch;
     this.numEpochs = numEpochs;
     this.numSamples = numSamples;
     this.trainIterator = trainIterator;


### PR DESCRIPTION
Dl4jMlpClassifier now supports resuming of training after user-specified number of epochs has completed (i.e. the network can be told to iterate for another x epochs). This allows serialized models to continue training at a later date. GUI/command-line support for this in Weka will be in 3.8.4/3.9.4 when released (and is available in nightly snapshots until that time). Also fixed command-line option handling for LogConfiguration.